### PR TITLE
Initial support for 2021.3 Alerts, some housekeeping

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -27,8 +27,15 @@ if ($suffix) {
     & dotnet publish -c Release -o ./obj/publish
     & dotnet pack -c Release -o ..\Artifacts --no-build
 }
-if($LASTEXITCODE -ne 0) { exit 1 }    
+if($LASTEXITCODE -ne 0) { exit 2 }
 
 Pop-Location
+Push-Location Seq.App.Teams.Tests
 
+echo "build: Testing"
+
+& dotnet test -c Release
+if($LASTEXITCODE -ne 0) { exit 3 }
+
+Pop-Location
 Pop-Location

--- a/Run.ps1
+++ b/Run.ps1
@@ -1,0 +1,11 @@
+param($WebhookUrl)
+
+echo "run: Publishing app binaries"
+
+& dotnet publish "$PSScriptRoot/Seq.App.Teams" -c Release -o "$PSScriptRoot/Seq.App.Teams/obj/publish" --version-suffix=local
+
+if($LASTEXITCODE -ne 0) { exit 1 }    
+
+echo "run: Piping live Seq logs to the app"
+
+& seqcli tail --json | & seqcli app run -d "$PSScriptRoot/Seq.App.Teams/obj/publish" -p TraceMessage=True -p TeamsBaseUrl="$WebhookUrl" 2>&1 | & seqcli print

--- a/Seq.App.Teams.Tests/Seq.App.Teams.Tests.csproj
+++ b/Seq.App.Teams.Tests/Seq.App.Teams.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Seq.App.Teams\Seq.App.Teams.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Seq.App.Teams.Tests/SeqEventsTests.cs
+++ b/Seq.App.Teams.Tests/SeqEventsTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using Seq.Apps;
+using Seq.Apps.LogEvents;
+using Xunit;
+
+namespace Seq.App.Teams.Tests
+{
+    public class SeqEventsTests
+    {
+        [Theory]
+        [InlineData("First", "`null`")]
+        [InlineData("Second", "20")]
+        [InlineData("Third", "System\\.Collections\\.Generic\\.Dictionary\\`2\\[System\\.String,System\\.Object\\]")]
+        [InlineData("Third.Fourth", "test")]
+        [InlineData("Fifth", "")]
+        public void PropertiesAreRetrievedFromTheEvent(string propertyPath, string expectedMarkdown)
+        {
+            var data = new LogEventData
+            {
+                Properties = new Dictionary<string, object>
+                {
+                    ["First"] = null,
+                    ["Second"] = 20,
+                    ["Third"] = new Dictionary<string, object>
+                    {
+                        ["Fourth"] = "test"
+                    }
+                }
+            };
+            
+            var evt = new Event<LogEventData>("event-123", 4, DateTime.UtcNow, data);
+
+            var actual = SeqEvents.GetProperty(evt, propertyPath);
+            Assert.Equal(expectedMarkdown, actual);
+        }
+
+        [Theory]
+        [InlineData("https://example.com", "event-123", "https://example.com/#/events?filter=@Id%20%3D%3D%20%22event-123%22&show=expanded")]
+        [InlineData("https://example.com/", "event-123", "https://example.com/#/events?filter=@Id%20%3D%3D%20%22event-123%22&show=expanded")]
+        [InlineData("https://example.com/test", "event-123", "https://example.com/test/#/events?filter=@Id%20%3D%3D%20%22event-123%22&show=expanded")]
+        [InlineData("https://example.com/test/", "event-123", "https://example.com/test/#/events?filter=@Id%20%3D%3D%20%22event-123%22&show=expanded")]
+        public void EventLinksAreGenerated(string seqBaseUrl, string eventId, string expectedLink)
+        {
+            var actual = SeqEvents.UILinkTo(
+                seqBaseUrl,
+                new Event<LogEventData>(eventId, 0, DateTime.UtcNow, new LogEventData()));
+            
+            Assert.Equal(expectedLink, actual);
+        }
+
+        [Theory]
+        [InlineData(1, "Open Seq Event")]
+        [InlineData(0xA1E77000, "Open Seq Alert")]
+        [InlineData(0xA1E77001, "Open Seq Alert")]
+        public void CorrectOpenLinkTitleIsIdentified(uint eventType, string expectedLinkTitle)
+        {
+            var (title, _) = SeqEvents.GetOpenLink(
+                "https://example.com",
+                new Event<LogEventData>("event-1", eventType, DateTime.UtcNow, new LogEventData()));
+            
+            Assert.Equal(title, expectedLinkTitle);
+        }
+    }
+}

--- a/Seq.App.Teams.sln
+++ b/Seq.App.Teams.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE = LICENSE
 		README.md = README.md
 		Build.ps1 = Build.ps1
+		Run.ps1 = Run.ps1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{A1F6682D-5638-41FB-8D67-8E8D961F861D}"
@@ -25,6 +26,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Assets", "Assets", "{B08B5B
 		Assets\microsoft-teams.png = Assets\microsoft-teams.png
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seq.App.Teams.Tests", "Seq.App.Teams.Tests\Seq.App.Teams.Tests.csproj", "{971F2FDD-EC57-4E9D-8317-C99AFE87B575}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +38,10 @@ Global
 		{30AEE6A3-E6FD-4229-86A1-4B3B7DB6A505}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{30AEE6A3-E6FD-4229-86A1-4B3B7DB6A505}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{30AEE6A3-E6FD-4229-86A1-4B3B7DB6A505}.Release|Any CPU.Build.0 = Release|Any CPU
+		{971F2FDD-EC57-4E9D-8317-C99AFE87B575}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{971F2FDD-EC57-4E9D-8317-C99AFE87B575}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{971F2FDD-EC57-4E9D-8317-C99AFE87B575}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{971F2FDD-EC57-4E9D-8317-C99AFE87B575}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Seq.App.Teams.sln.DotSettings
+++ b/Seq.App.Teams.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Seq_0027s/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Seq.App.Teams/SeqEvents.cs
+++ b/Seq.App.Teams/SeqEvents.cs
@@ -17,7 +17,7 @@ namespace Seq.App.Teams
 
             if (evt.EventType == AlertV2EventType)
             {
-                return ("Open Seq Alert", GetProperty(evt, "Source.ResultsUrl"));
+                return ("Open Seq Alert", GetProperty(evt, "Source.ResultsUrl", raw: true));
             }
 
             return ("Open Seq Event", UILinkTo(seqBaseUrl, evt));

--- a/Seq.App.Teams/SeqEvents.cs
+++ b/Seq.App.Teams/SeqEvents.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using Seq.Apps;
+using Seq.Apps.LogEvents;
+
+namespace Seq.App.Teams
+{
+    public static class SeqEvents
+    {
+        private const uint AlertV1EventType = 0xA1E77000, AlertV2EventType = 0xA1E77001;
+        
+        public static (string description, string href) GetOpenLink(string seqBaseUrl, Event<LogEventData> evt)
+        {
+            if (evt.EventType == AlertV1EventType)
+            {
+                return ("Open Seq Alert", GetProperty(evt, "ResultsUrl", raw: true));
+            }
+
+            if (evt.EventType == AlertV2EventType)
+            {
+                return ("Open Seq Alert", GetProperty(evt, "Source.ResultsUrl"));
+            }
+
+            return ("Open Seq Event", UILinkTo(seqBaseUrl, evt));
+        }
+        
+        public static string GetProperty(Event<LogEventData> evt, string propertyPath, bool raw = false)
+        {
+            var path = new Queue<string>(propertyPath.Split('.'));
+            var root = evt.Data.Properties;
+
+            while(root != null)
+            {
+                var step = path.Dequeue();
+                if (!root.TryGetValue(step, out var next))
+                    return "";
+
+                if (path.Count == 0)
+                {
+                    if (next == null) return "`null`";
+                    return raw ? next.ToString() : next.ToString().EscapeMarkdown();
+                }
+
+                root = next as IReadOnlyDictionary<string, object>;
+            }
+
+            return "";
+        }
+        
+        public static string UILinkTo(string seqBaseUrl, Event<LogEventData> evt)
+        {
+            return $"{seqBaseUrl.TrimEnd('/')}/#/events?filter=@Id%20%3D%3D%20%22{evt.Id}%22&show=expanded";
+        }
+    }
+}

--- a/Seq.App.Teams/TeamsApp.cs
+++ b/Seq.App.Teams/TeamsApp.cs
@@ -10,15 +10,17 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+using Serilog;
+
+// ReSharper disable UnusedAutoPropertyAccessor.Global, MemberCanBePrivate.Global, UnusedType.Global
 
 namespace Seq.App.Teams
 {
     [SeqApp("Teams",
-    Description = "Sends log events to Microsoft Teams.")]
+    Description = "Sends events and notifications to Microsoft Teams.")]
     public class TeamsApp : SeqApp, ISubscribeToAsync<LogEventData>
     {
-        
-        private static readonly IDictionary<LogEventLevel, string> _levelColorMap = new Dictionary<LogEventLevel, string>
+        private static readonly IDictionary<LogEventLevel, string> LevelColorMap = new Dictionary<LogEventLevel, string>
         {
             {LogEventLevel.Verbose, "808080"},
             {LogEventLevel.Debug, "808080"},
@@ -27,14 +29,16 @@ namespace Seq.App.Teams
             {LogEventLevel.Error, "ff0000"},
             {LogEventLevel.Fatal, "ff0000"}
         };
-
-        private const uint AlertEventType = 0xA1E77000;
+        
+        private HttpClientHandler _httpClientHandler;
+        private ILogger _log;
 
         #region "Settings"
+        
         [SeqAppSetting(
-        DisplayName = "Seq Base URL",
-        HelpText = "Used for generating perma links to events in Teams messages.",
-        IsOptional = true)]
+            DisplayName = "Seq Base URL",
+            HelpText = "Used for generating links to events in Teams messages; if not specified, Seq's configured base URL will be used.",
+            IsOptional = true)]
         public string BaseUrl { get; set; }
 
         [SeqAppSetting(
@@ -57,52 +61,73 @@ namespace Seq.App.Teams
         public string WebProxyPassword { get; set; }
 
         [SeqAppSetting(
-        DisplayName = "Teams WebHook URL",
-        HelpText = "Used to send message to Teams. This can be retrieved by adding a Incoming Webhook connector to your Teams channel.")]
+            DisplayName = "Teams WebHook URL",
+            HelpText = "Used to send message to Teams. This can be retrieved by adding a Incoming Webhook connector to your Teams channel.")]
         public string TeamsBaseUrl { get; set; }
 
         [SeqAppSetting(
-        DisplayName = "Trace All Messages",
-        HelpText = "Used to show all messages to trace",
-        IsOptional = true)]
+            DisplayName = "Trace All Messages",
+            HelpText = "Used to show all messages to trace; note that this will cause the Teams Webhook URL to appear in diagnostic messages.",
+            IsOptional = true)]
         public bool TraceMessage { get; set; }
 
         [SeqAppSetting(
-        DisplayName = "Exclude Properties",
-        HelpText = "Exclude the Seq properties from the messages",
-        IsOptional = true)]
+            DisplayName = "Exclude Properties",
+            HelpText = "Exclude the Seq properties from the messages",
+            IsOptional = true)]
         public bool ExcludeProperties { get; set; }
 
         [SeqAppSetting(
-        DisplayName = "Properties to serialize as JSON",
-        HelpText = "The properties that should be serialized as JSON instead of the native ToString() on the value. Multiple properties can be specified; enter one per line.",
-        InputType = SettingInputType.LongText,
-        IsOptional = true)]
+            DisplayName = "Properties to serialize as JSON",
+            HelpText = "The properties that should be serialized as JSON instead of the native ToString() on the value. Multiple properties can be specified; enter one per line.",
+            InputType = SettingInputType.LongText,
+            IsOptional = true)]
         public string JsonSerializedProperties { get; set; }
 
         [SeqAppSetting(
-        DisplayName = "Properties to serialize as JSON - Use Indented JSON?",
-        HelpText = "For properties that are serialized as JSON, should they be indented?",
-        InputType = SettingInputType.Checkbox,
-        IsOptional = true)]
+            DisplayName = "Properties to serialize as JSON - Use Indented JSON?",
+            HelpText = "For properties that are serialized as JSON, should they be indented?",
+            InputType = SettingInputType.Checkbox,
+            IsOptional = true)]
         public bool JsonSerializedPropertiesAsIndented { get; set; }
 
         [SeqAppSetting(
-        DisplayName = "Color",
-        HelpText = "Hex theme color for messages (ex. ff0000). (default: auto based on message level)",
-        IsOptional = true)]
+            DisplayName = "Color",
+            HelpText = "Hex theme color for messages (ex. ff0000). (default: auto based on message level)",
+            IsOptional = true)]
         public string Color { get; set; }
 
-        [SeqAppSetting(DisplayName = "Comma seperated list of event levels",
-        IsOptional = true,
-        HelpText = "If specified Teams card will be created only for the specified event levels, other levels will be discarded (useful for streaming events). Valid Values: Verbose,Debug,Information,Warning,Error,Fatal")]
+        [SeqAppSetting(
+            DisplayName = "Comma seperated list of event levels",
+            IsOptional = true,
+            HelpText = "If specified Teams card will be created only for the specified event levels, other levels will be discarded (useful for streaming events). Valid Values: Verbose,Debug,Information,Warning,Error,Fatal")]
         public string LogEventLevels { get; set; }
 
         #endregion
 
+        protected override void OnAttached()
+        {
+            _log = TraceMessage ? Log.ForContext("Uri", TeamsBaseUrl) : Log;
+            
+            _httpClientHandler = new HttpClientHandler();
+            if (!string.IsNullOrEmpty(WebProxy))
+            {
+                ICredentials credentials = null;
+                if (!string.IsNullOrEmpty(WebProxyUserName))
+                {
+                    credentials = new NetworkCredential(WebProxyUserName, WebProxyPassword);
+                }
+                _httpClientHandler.Proxy = new WebProxy(WebProxy, false, null, credentials);
+                _httpClientHandler.UseProxy = true;
+            }
+            else
+            {
+                _httpClientHandler.UseProxy = false;
+            }
+        }
+
         public async Task OnAsync(Event<LogEventData> evt)
         {
-
             try
             {
                 //If the event level is defined and it is not in the list do not log it
@@ -111,89 +136,60 @@ namespace Seq.App.Teams
 
                 if (TraceMessage)
                 {
-                    Log
-                        .ForContext("Uri", new Uri(TeamsBaseUrl))
-                        .Information("Start Processing {Message}", evt.Data.RenderedMessage);
+                    _log.Information("Start Processing {Message}", evt.Data.RenderedMessage);
                 }
-
-                O365ConnectorCard body = BuildBody(evt);
-
-                var httpClientHandler = new HttpClientHandler();
-
-                if (!string.IsNullOrEmpty(WebProxy))
-                {
-                    ICredentials credentials = null;
-                    if (!string.IsNullOrEmpty(WebProxyUserName))
-                    {
-                        credentials = new NetworkCredential(WebProxyUserName, WebProxyPassword);
-                    }
-                    httpClientHandler.Proxy = new WebProxy(WebProxy, false, null, credentials);
-                    httpClientHandler.UseProxy = true;
-                }
-                else
-                {
-                    httpClientHandler.UseProxy = false;
-                }
-
-                using (var client = new HttpClient(httpClientHandler))
+                
+                using (var client = new HttpClient(_httpClientHandler))
                 {
                     client.BaseAddress = new Uri(TeamsBaseUrl);
 
                     client.DefaultRequestHeaders.Accept.Clear();
                     client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-                    var js = new JsonSerializerSettings();
-                    js.NullValueHandling = NullValueHandling.Ignore;
+                    var js = new JsonSerializerSettings
+                    {
+                        NullValueHandling = NullValueHandling.Ignore
+                    };
 
+                    O365ConnectorCard body = BuildBody(evt);
                     var bodyJson = JsonConvert.SerializeObject(body, js);
-                    var response = await client.PostAsync(
-                        "", 
-                        new StringContent(bodyJson, Encoding.UTF8, "application/json")
-                        );
+                    var response = await client.PostAsync("", new StringContent(bodyJson, Encoding.UTF8, "application/json"));
 
                     if (!response.IsSuccessStatusCode)
                     {
-                        Log
-                            .ForContext("Uri", response.RequestMessage.RequestUri)
-                            .Error("Could not send Teams message, server replied {StatusCode} {StatusMessage}: {Message}. Request Body: {RequestBody}", Convert.ToInt32(response.StatusCode), response.StatusCode, await response.Content.ReadAsStringAsync(), bodyJson);
+                        _log.Error("Could not send Teams message, server replied {StatusCode} {StatusMessage}: {Message}. Request Body: {RequestBody}", Convert.ToInt32(response.StatusCode), response.StatusCode, await response.Content.ReadAsStringAsync(), bodyJson);
                     }
                     else
                     {
                         if (TraceMessage)
                         {
-                            string reponseResult = await response.Content.ReadAsStringAsync();
-                            Log
-                                .ForContext("Uri", response.RequestMessage.RequestUri)
-                                .Information("Server replied {StatusCode} {StatusMessage}: {Message}", Convert.ToInt32(response.StatusCode), response.StatusCode, reponseResult);
+                            var responseResult = await response.Content.ReadAsStringAsync();
+                            _log.Information("Server replied {StatusCode} {StatusMessage}: {Message}", Convert.ToInt32(response.StatusCode), response.StatusCode, responseResult);
                         }
                     }
                 }
             }
             catch (Exception ex)
             {
-
-                Log
-                    .ForContext("Uri", new Uri(TeamsBaseUrl))
-                    .Error(ex, "An error occured while constructing request.");
+               _log.Error(ex, "An error occured while constructing the request");
             }
         }
 
-        public List<LogEventLevel> LogEventLevelList
+        private List<LogEventLevel> LogEventLevelList
         {
             get
             {
-                List<LogEventLevel> result = new List<LogEventLevel>();
+                var result = new List<LogEventLevel>();
                 if (string.IsNullOrEmpty(LogEventLevels))
                     return result;
 
-                var strValues = LogEventLevels.Split(new char[1] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                var strValues = LogEventLevels.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 if ((strValues?.Length ?? 0) == 0)
                     return result;
 
                 strValues.Aggregate(result, (acc, strValue) =>
                 {
-                    LogEventLevel enumValue = LogEventLevel.Debug;
-                    if (Enum.TryParse(strValue, out enumValue))
+                    if (Enum.TryParse(strValue, out LogEventLevel enumValue))
                         acc.Add(enumValue);
                     return acc;
                 });
@@ -209,22 +205,17 @@ namespace Seq.App.Teams
             if (string.IsNullOrWhiteSpace(url))
                 url = Host.BaseUri;
 
-            var openTitle = "Open Seq Event";
-            var openUrl = $"{url}#/events?filter=@Id%20%3D%3D%20%22{evt.Id}%22&show=expanded";
-            if (IsAlert(evt))
-            {
-                openTitle = "Open Seq Alert";
-                openUrl = SafeGetProperty(evt, "ResultsUrl");
-            }
-
-            O365ConnectorCardOpenUri action = new O365ConnectorCardOpenUri()
+            var (openTitle, openUrl) = SeqEvents.GetOpenLink(url, evt);
+            var action = new O365ConnectorCardOpenUri
             {
                 Name = openTitle,
                 Type = "OpenUri", //Failure to provide this will cause a 400 badrequest
                 Targets = new[]
                 {
-                    new O365ConnectorCardOpenUriTarget { Uri = openUrl,
-                    Os = "default" //Failure to provide this will cause a 400 badrequest
+                    new O365ConnectorCardOpenUriTarget
+                    {
+                        Uri = openUrl,
+                        Os = "default" //Failure to provide this will cause a 400 badrequest
                     }
                 }
             };
@@ -237,15 +228,15 @@ namespace Seq.App.Teams
             var color = Color;
             if (string.IsNullOrWhiteSpace(color))
             {
-                color = _levelColorMap[evt.Data.Level];
+                color = LevelColorMap[evt.Data.Level];
             }
 
-            O365MessageCard body = new O365MessageCard
+            var body = new O365MessageCard
             {
                 Title = evt.Data.Level.ToString().EscapeMarkdown(),
                 ThemeColor = color,
                 Text = msg,
-                PotentialAction = new[]
+                PotentialAction = new O365ConnectorCardActionBase[]
                 {
                     action
                 }
@@ -281,26 +272,6 @@ namespace Seq.App.Teams
             body.Sections = sections.ToArray();
 
             return body;
-        }
-
-        /// <summary>
-        /// Dashboard alerts create a "virtual" event id, so it doesn't actually point to a specific log, but potentially a set of log events
-        /// </summary>
-        /// <param name="evt"></param>
-        /// <returns></returns>
-        private static bool IsAlert(Event<LogEventData> evt)
-        {
-            return evt.EventType == AlertEventType;
-        }
-
-        private static string SafeGetProperty(Event<LogEventData> evt, string propertyName)
-        {
-            if (evt.Data.Properties.TryGetValue(propertyName, out var value))
-            {
-                if (value == null) return "`null`";
-                return value.ToString();
-            }
-            return "";
         }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 version: '{build}'
 skip_tags: true
 image: Visual Studio 2019
-install:
 build_script:
   - ps: ./Build.ps1
 test: off


### PR DESCRIPTION
Since there's quite a bit more information we can add to the 2021.3 alerts, to keep the size of the PR manageable and to make things reviewable, I thought I'd send this checkpoint PR first

This PR:

 * Pulls some of the Seq event recognition/handling logic out into its own class
 * Adds a test project and some tests for the above
 * Moves as much initialization as possible to the `OnAttached()` hook
 * Adds `Run.ps1`, which will use `seqcli` (if installed) to run the app outside of Seq (avoiding packaging/app installation etc. for debugging 🎉 )
 * Sets the correct "open" URL for 2021.3 alerts, when they're encountered
 * Attempts to fix some inconsistent whitespace

There's one small functional change: the code only includes the (potentially sensitive?) Teams webhook URL in diagnostic events when the `TraceMessage` flag is enabled, and adds a warning about this to the help text for that property. My reasoning is that it's not otherwise apparent that the webhook URL will end up in Seq events when errors occur (thoughts?).

Still works as before, on my local instance:

![Seq event shown in Teams](https://user-images.githubusercontent.com/342712/136313248-9c25e640-946d-4cb6-baec-f4172099fe65.png)

I tried to follow the project's style/conventions as much as possible, but I'm not 100% sure of the intention in all places, so if there's anything you'd like tweaked or reverted no matter how trivial, as always, please just let me know :-)