### PR TITLE
Fixes #23 - HttpClient should not dispose inner HttpClientHandler

### DIFF
--- a/Seq.App.Teams/TeamsApp.cs
+++ b/Seq.App.Teams/TeamsApp.cs
@@ -139,7 +139,7 @@ namespace Seq.App.Teams
                     _log.Information("Start Processing {Message}", evt.Data.RenderedMessage);
                 }
                 
-                using (var client = new HttpClient(_httpClientHandler))
+                using (var client = new HttpClient(_httpClientHandler, disposeHandler: false))
                 {
                     client.BaseAddress = new Uri(TeamsBaseUrl);
 


### PR DESCRIPTION
We could also consider reusing the `HttpClient`, though I've hit issues in the past with DNS updates not being picked up by long-lived `HttpClient`s, so I'd lean towards leaving things as they are, for now.