### PR TITLE
Improving property serialization and configuration

### DIFF
--- a/Seq.App.Teams/PropertyConfig.cs
+++ b/Seq.App.Teams/PropertyConfig.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Seq.App.Teams
+{
+    public class PropertyConfig
+    {
+        public List<string> JsonSerializedProperties { get; set; } = new List<string>();
+        public List<string> ExcludedProperties { get; set; } = new List<string>();
+        public bool JsonSerializedPropertiesAsIndented { get; set; }
+        public bool SkipEscapeMarkDown { get; set; }
+    }
+}

--- a/Seq.App.Teams/SeqEvents.cs
+++ b/Seq.App.Teams/SeqEvents.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
 using Seq.Apps;
 using Seq.Apps.LogEvents;
 
@@ -7,48 +9,96 @@ namespace Seq.App.Teams
     public static class SeqEvents
     {
         private const uint AlertV1EventType = 0xA1E77000, AlertV2EventType = 0xA1E77001;
-        
+
+        private static readonly JsonSerializerSettings JsonSettingsDefault = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            Formatting = Formatting.None
+        };
+        private static readonly JsonSerializerSettings JsonSettingsIndented = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            Formatting = Formatting.Indented
+        };
+
         public static (string description, string href) GetOpenLink(string seqBaseUrl, Event<LogEventData> evt)
         {
+            var config = new PropertyConfig { SkipEscapeMarkDown = true };
+
             if (evt.EventType == AlertV1EventType)
             {
-                return ("Open Seq Alert", GetProperty(evt, "ResultsUrl", raw: true));
+                return ("Open Seq Alert", GetProperty(evt, "ResultsUrl", config));
             }
 
             if (evt.EventType == AlertV2EventType)
             {
-                return ("Open Seq Alert", GetProperty(evt, "Source.ResultsUrl", raw: true));
+                return ("Open Seq Alert", GetProperty(evt, "Source.ResultsUrl", config));
             }
 
             return ("Open Seq Event", UILinkTo(seqBaseUrl, evt));
         }
-        
-        public static string GetProperty(Event<LogEventData> evt, string propertyPath, bool raw = false)
+
+        public static string GetProperty(Event<LogEventData> evt, string propertyPath, PropertyConfig config = null)
         {
-            var path = new Queue<string>(propertyPath.Split('.'));
-            var root = evt.Data.Properties;
+            var properties = GetProperties(evt, config ?? new PropertyConfig());
 
-            while(root != null)
-            {
-                var step = path.Dequeue();
-                if (!root.TryGetValue(step, out var next))
-                    return "";
-
-                if (path.Count == 0)
-                {
-                    if (next == null) return "`null`";
-                    return raw ? next.ToString() : next.ToString().EscapeMarkdown();
-                }
-
-                root = next as IReadOnlyDictionary<string, object>;
-            }
-
-            return "";
+            return properties.TryGetValue(propertyPath, out var value) ? value : "";
         }
-        
+
+        public static IDictionary<string, string> GetProperties(Event<LogEventData> evt, PropertyConfig config)
+        {
+            return GetProperties(evt.Data.Properties, config, "").ToDictionary(x => x.Key, x => x.Value);
+        }
+
         public static string UILinkTo(string seqBaseUrl, Event<LogEventData> evt)
         {
             return $"{seqBaseUrl.TrimEnd('/')}/#/events?filter=@Id%20%3D%3D%20%22{evt.Id}%22&show=expanded";
+        }
+
+        private static IEnumerable<KeyValuePair<string, string>> GetProperties(IReadOnlyDictionary<string, object> properties, PropertyConfig config, string parentPropertyPath)
+        {
+            if (properties == null) yield break;
+
+            foreach (var property in properties)
+            {
+                var propertyPath = $"{parentPropertyPath}.{property.Key}".TrimStart(new[] { '.' });
+
+                if (config.ExcludedProperties.Contains(propertyPath)) continue;
+
+                if (property.Value is IReadOnlyDictionary<string, object> childProperties && !config.JsonSerializedProperties.Contains(propertyPath))
+                {
+                    foreach (var nestedProperty in GetProperties(childProperties, config, propertyPath))
+                    {
+                        yield return nestedProperty;
+                    }
+                }
+                else
+                {
+                    yield return new KeyValuePair<string, string>(propertyPath, GetPropertyValue(propertyPath, property, config));
+                }
+            }
+        }
+
+        private static string GetPropertyValue(string propertyPath, KeyValuePair<string, object> property, PropertyConfig config)
+        {
+            string value;
+
+            if (property.Value is null)
+            {
+                return "`null`";
+            }
+            else if (config.JsonSerializedProperties.Contains(propertyPath))
+            {
+                var settings = config.JsonSerializedPropertiesAsIndented ? JsonSettingsIndented : JsonSettingsDefault;
+
+                value = JsonConvert.SerializeObject(property.Value, settings);
+            }
+            else
+            {
+                value = property.Value.ToString();
+            }
+
+            return config.SkipEscapeMarkDown ? value : value.EscapeMarkdown();
         }
     }
 }


### PR DESCRIPTION
I changed the processing of properties to always be recursive in the case of nested dictionaries. Passing down configuration allowed me to parse certain properties as JSON while by default adding them to the card instead of the output of ToString on a dictionary.

I changed the `ExcludeProperties` boolean to a `ExcludedProperties` string list so there can be a more finer control of which properties to exclude. While allowing to the previous behavior with a special property name `All` to indicate all Seq properties should be ignored. 

Unit tests have been expanded, only when manually trying to test the code I ran into some problems. Running `Run.ps1` with the correct webhook parameter did nothing. I get no output. `seq tail --json` does give me output so there is either something going wrong with piping the events or there is actually something going wrong in the app, only I get no output. So help in that area is needed.

This should technically resolve https://github.com/AntoineGa/Seq.App.Teams/issues/32 without having to configure any properties to be serialized as JSON.